### PR TITLE
Allow image size to be adjusted for active camera stream

### DIFF
--- a/media/query.go
+++ b/media/query.go
@@ -199,6 +199,13 @@ func newVideoReaderFromDriver(videoDriver driver.Driver, mediaProp prop.Media) (
 	if !ok {
 		return nil, errors.New("driver not a driver.VideoRecorder")
 	}
+
+	if driverStatus := videoDriver.Status(); driverStatus != driver.StateClosed {
+		gostream.Logger.Warnw("video driver is not closed, attempting to close and reopen", "status", driverStatus)
+		if err := videoDriver.Close(); err != nil {
+			gostream.Logger.Errorw("error closing driver", "error", err)
+		}
+	}
 	if err := videoDriver.Open(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds two changes to support stream adjustments for active cameras:
* Close and reopen the active video driver
* Detect image size changes 

Related RDK change: https://github.com/viamrobotics/rdk/pull/581