### PR TITLE
Keep driver open until no video readers reference them

### DIFF
--- a/media/query.go
+++ b/media/query.go
@@ -213,7 +213,7 @@ func newVideoReaderFromDriver(videoDriver driver.Driver, mediaProp prop.Media) (
 	if err != nil {
 		return nil, err
 	}
-	return &videoReadCloser{videoDriver, reader}, nil
+	return NewVideoReadCloser(videoDriver, reader), nil
 }
 
 func labelFilter(target string, useSep bool) driver.FilterFn {

--- a/media/video.go
+++ b/media/video.go
@@ -70,7 +70,9 @@ func (vrc videoReadCloser) Close() error {
 	label := vrc.videoDriver.Info().Label
 	if rcv, ok := driverRefs.refs[label]; ok {
 		if rcv.Deref() {
+			delete(driverRefs.refs, label)
 			// TODO: get the driver from the refs map?
+			// TODO: what if there is an error closing the library?
 			return vrc.videoDriver.Close()
 		}
 	} else {

--- a/media/video.go
+++ b/media/video.go
@@ -11,7 +11,7 @@ import (
 	"go.viam.com/utils"
 )
 
-// ErrDriverInUse
+// ErrDriverInUse is returned when closing drivers that still being read from.
 type ErrDriverInUse struct {
 	label string
 }

--- a/media/video.go
+++ b/media/video.go
@@ -17,7 +17,7 @@ type ErrDriverInUse struct {
 }
 
 func (err *ErrDriverInUse) Error() string {
-	return fmt.Sprintf("driver is still in use: %v", err.label)
+	return fmt.Sprintf("driver is still in use: %s", err.label)
 }
 
 // driverRefManager is a lockable map of drivers and reference counts of video readers

--- a/media/video.go
+++ b/media/video.go
@@ -54,11 +54,9 @@ func NewVideoReadCloser(d driver.Driver, r video.Reader) *videoReadCloser {
 
 	label := d.Info().Label
 	if rcv, ok := driverRefs.refs[label]; ok {
-		// TODO: get the existing driver?
 		rcv.Ref()
 	} else {
 		driverRefs.refs[label] = utils.NewRefCountedValue(d)
-		// TODO: get the existing driver?
 		driverRefs.refs[label].Ref()
 	}
 
@@ -81,12 +79,9 @@ func (vrc videoReadCloser) Close() error {
 	if rcv, ok := driverRefs.refs[label]; ok {
 		if rcv.Deref() {
 			delete(driverRefs.refs, label)
-			// TODO: get the driver from the refs map?
-			// TODO: what if there is an error closing the library?
 			return vrc.videoDriver.Close()
 		}
 	} else {
-		// No known references, close the driver
 		return vrc.videoDriver.Close()
 	}
 

--- a/media/video.go
+++ b/media/video.go
@@ -11,13 +11,14 @@ import (
 	"go.viam.com/utils"
 )
 
-// driverRefManager is a global map of drivers and how often they are referenced by video
-// readers
+// driverRefManager is a lockable map of drivers and reference counts of video readers
+// that use them.
 type driverRefManager struct {
 	refs map[string]utils.RefCountedValue
 	mu   sync.Mutex
 }
 
+// initialize a global driverRefManager
 var driverRefs = driverRefManager{refs: map[string]utils.RefCountedValue{}}
 
 // A VideoReadCloser is a video.Reader that requires it be closed.

--- a/media/video.go
+++ b/media/video.go
@@ -3,10 +3,22 @@ package media
 import (
 	"context"
 	"image"
+	"sync"
 
+	"github.com/edaniels/gostream"
 	"github.com/pion/mediadevices/pkg/driver"
 	"github.com/pion/mediadevices/pkg/io/video"
+	"go.viam.com/utils"
 )
+
+// driverRefManager is a global map of drivers and how often they are referenced by video
+// readers
+type driverRefManager struct {
+	refs map[string]utils.RefCountedValue
+	mu   sync.Mutex
+}
+
+var driverRefs = driverRefManager{refs: map[string]utils.RefCountedValue{}}
 
 // A VideoReadCloser is a video.Reader that requires it be closed.
 type VideoReadCloser interface {
@@ -24,6 +36,25 @@ type videoReadCloser struct {
 	videoReader video.Reader
 }
 
+// NewVideoReadCloser instantiates a new video read closer and references the given
+// driver.
+func NewVideoReadCloser(d driver.Driver, r video.Reader) *videoReadCloser {
+	driverRefs.mu.Lock()
+	defer driverRefs.mu.Unlock()
+
+	label := d.Info().Label
+	if rcv, ok := driverRefs.refs[label]; ok {
+		// TODO: get the existing driver?
+		rcv.Ref()
+	} else {
+		driverRefs.refs[label] = utils.NewRefCountedValue(d)
+		// TODO: get the existing driver?
+		driverRefs.refs[label].Ref()
+	}
+
+	return &videoReadCloser{d, r}
+}
+
 func (vrc videoReadCloser) Read() (image.Image, func(), error) {
 	return vrc.videoReader.Read()
 }
@@ -33,5 +64,23 @@ func (vrc videoReadCloser) Next(ctx context.Context) (image.Image, func(), error
 }
 
 func (vrc videoReadCloser) Close() error {
-	return vrc.videoDriver.Close()
+	driverRefs.mu.Lock()
+	defer driverRefs.mu.Unlock()
+
+	label := vrc.videoDriver.Info().Label
+	if rcv, ok := driverRefs.refs[label]; ok {
+		if rcv.Deref() {
+			// TODO: get the driver from the refs map?
+			return vrc.videoDriver.Close()
+		}
+	} else {
+		// No known references, close the driver
+		return vrc.videoDriver.Close()
+	}
+
+	// Do not close if a driver is being referenced.
+	// TODO: should we throw an error here and let clients decide whether to proceed
+	// silently or not?
+	gostream.Logger.Warnw("driver is still in use, will not close", "driver", label)
+	return nil
 }

--- a/media/video_test.go
+++ b/media/video_test.go
@@ -50,12 +50,8 @@ func newFakeReader() video.Reader {
 func TestReaderClose(t *testing.T) {
 	d := newFakeDriver("/dev/fake")
 
-	r1 := newFakeReader()
-	r2 := newFakeReader()
-
-	// TODO: make package test_media and import this function from media
-	vrc1 := media.NewVideoReadCloser(d, r1)
-	vrc2 := media.NewVideoReadCloser(d, r2)
+	vrc1 := media.NewVideoReadCloser(d, newFakeReader())
+	vrc2 := media.NewVideoReadCloser(d, newFakeReader())
 
 	if closedCount := d.(*fakeDriver).closedCount; closedCount != 0 {
 		t.Fatalf("expected driver to be open, but was closed %d times", closedCount)

--- a/media/video_test.go
+++ b/media/video_test.go
@@ -1,14 +1,17 @@
-package media
+package media_test
 
 import (
 	"image"
 	"testing"
 
+	"github.com/edaniels/gostream/media"
 	"github.com/pion/mediadevices/pkg/prop"
 
 	"github.com/pion/mediadevices/pkg/driver"
 	"github.com/pion/mediadevices/pkg/io/video"
 )
+
+// MOCKS
 
 // fakeDriver is a driver has a label and keeps track of how many times it is closed.
 type fakeDriver struct {
@@ -42,6 +45,8 @@ func newFakeReader() video.Reader {
 	return &fakeReader{}
 }
 
+// TESTS
+
 func TestReaderClose(t *testing.T) {
 	d := newFakeDriver("/dev/fake")
 
@@ -49,8 +54,8 @@ func TestReaderClose(t *testing.T) {
 	r2 := newFakeReader()
 
 	// TODO: make package test_media and import this function from media
-	vrc1 := NewVideoReadCloser(d, r1)
-	vrc2 := NewVideoReadCloser(d, r2)
+	vrc1 := media.NewVideoReadCloser(d, r1)
+	vrc2 := media.NewVideoReadCloser(d, r2)
 
 	if closedCount := d.(*fakeDriver).closedCount; closedCount != 0 {
 		t.Fatalf("expected driver to be open, but was closed %d times", closedCount)
@@ -58,7 +63,7 @@ func TestReaderClose(t *testing.T) {
 
 	// Close first reader.
 	err := vrc1.Close()
-	_, ok := err.(*ErrDriverInUse)
+	_, ok := err.(*media.ErrDriverInUse)
 	if err == nil || !ok {
 		t.Fatalf("expected driver-in-use error, got %v", err)
 	}

--- a/media/video_test.go
+++ b/media/video_test.go
@@ -1,0 +1,79 @@
+package media
+
+import (
+	"image"
+	"testing"
+
+	"github.com/pion/mediadevices/pkg/prop"
+
+	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pion/mediadevices/pkg/io/video"
+)
+
+// fakeDriver is a driver has a label and keeps track of how many times it is closed.
+type fakeDriver struct {
+	label       string
+	closedCount int
+}
+
+func (d *fakeDriver) Open() error              { return nil }
+func (d *fakeDriver) Properties() []prop.Media { return []prop.Media{} }
+func (d *fakeDriver) ID() string               { return d.label }
+func (d *fakeDriver) Info() driver.Info        { return driver.Info{Label: d.label} }
+func (d *fakeDriver) Status() driver.State     { return "FakeState" }
+
+func (d *fakeDriver) Close() error {
+	d.closedCount++
+	return nil
+}
+
+func newFakeDriver(label string) driver.Driver {
+	return &fakeDriver{label: label}
+}
+
+// fakeReader is a reader that always returns a pixel-sized canvas.
+type fakeReader struct{}
+
+func (r *fakeReader) Read() (img image.Image, release func(), err error) {
+	return image.NewNRGBA(image.Rect(0, 0, 1, 1)), func() {}, nil
+}
+
+func newFakeReader() video.Reader {
+	return &fakeReader{}
+}
+
+func TestReaderClose(t *testing.T) {
+	d := newFakeDriver("/dev/fake")
+
+	r1 := newFakeReader()
+	r2 := newFakeReader()
+
+	// TODO: make package test_media and import this function from media
+	vrc1 := NewVideoReadCloser(d, r1)
+	vrc2 := NewVideoReadCloser(d, r2)
+
+	if closedCount := d.(*fakeDriver).closedCount; closedCount != 0 {
+		t.Fatalf("expected driver to be open, but was closed %d times", closedCount)
+	}
+
+	// Close first reader.
+	err := vrc1.Close()
+	_, ok := err.(*ErrDriverInUse)
+	if err == nil || !ok {
+		t.Fatalf("expected driver-in-use error, got %v", err)
+	}
+
+	if closedCount := d.(*fakeDriver).closedCount; closedCount != 0 {
+		t.Fatalf("expected driver to be open, but was closed %d times", closedCount)
+	}
+
+	// Close second reader.
+	err = vrc2.Close()
+	if err != nil {
+		t.Fatalf("expected no errors, got %v", err)
+	}
+
+	if closedCount := d.(*fakeDriver).closedCount; closedCount != 1 {
+		t.Fatalf("expected driver to be closed once, but was closed %d times", closedCount)
+	}
+}


### PR DESCRIPTION
This change prevents a video reader from closing the underlying video driver if other video readers are using that driver.

Related to: https://github.com/viamrobotics/rdk/pull/581
