### PR TITLE
Expose "already registered" error

### DIFF
--- a/stream_server.go
+++ b/stream_server.go
@@ -11,6 +11,16 @@ import (
 	streampb "github.com/edaniels/gostream/proto/stream/v1"
 )
 
+// ErrAlreadyRegistered indicates that a stream has a name that is already registered on
+// the stream server.
+type ErrAlreadyRegistered struct {
+	name string
+}
+
+func (e *ErrAlreadyRegistered) Error() string {
+	return fmt.Sprintf("stream %q already registered", e.name)
+}
+
 // A StreamServer manages a collection of streams. Streams can be
 // added over time for future new connections.
 type StreamServer interface {
@@ -57,7 +67,7 @@ func (ss *streamServer) AddStream(stream Stream) error {
 func (ss *streamServer) addStream(stream Stream) error {
 	streamName := stream.Name()
 	if _, ok := ss.nameToStream[streamName]; ok {
-		return fmt.Errorf("stream %q already registered", streamName)
+		return &ErrAlreadyRegistered{streamName}
 	}
 	ss.nameToStream[streamName] = stream
 	ss.streams = append(ss.streams, stream)

--- a/stream_server.go
+++ b/stream_server.go
@@ -11,13 +11,13 @@ import (
 	streampb "github.com/edaniels/gostream/proto/stream/v1"
 )
 
-// ErrAlreadyRegistered indicates that a stream has a name that is already registered on
+// ErrStreamAlreadyRegistered indicates that a stream has a name that is already registered on
 // the stream server.
-type ErrAlreadyRegistered struct {
+type ErrStreamAlreadyRegistered struct {
 	name string
 }
 
-func (e *ErrAlreadyRegistered) Error() string {
+func (e *ErrStreamAlreadyRegistered) Error() string {
 	return fmt.Sprintf("stream %q already registered", e.name)
 }
 
@@ -67,7 +67,7 @@ func (ss *streamServer) AddStream(stream Stream) error {
 func (ss *streamServer) addStream(stream Stream) error {
 	streamName := stream.Name()
 	if _, ok := ss.nameToStream[streamName]; ok {
-		return &ErrAlreadyRegistered{streamName}
+		return &ErrStreamAlreadyRegistered{streamName}
 	}
 	ss.nameToStream[streamName] = stream
 	ss.streams = append(ss.streams, stream)


### PR DESCRIPTION
Prerequisite for: https://github.com/viamrobotics/rdk/pull/776

Codifies error related to re-registering an existing stream name.
