### PR TITLE
fix global logger

### DIFF
--- a/cmd/stream_audio/main.go
+++ b/cmd/stream_audio/main.go
@@ -30,7 +30,7 @@ func main() {
 
 var (
 	defaultPort = 5555
-	logger      = golog.Global.Named("server")
+	logger      = golog.Global().Named("server")
 )
 
 // Arguments for the command.


### PR DESCRIPTION
Fixes the issue
```
$ make build-go 
...
cmd/stream_audio/main.go:33:29: golog.Global.Named undefined (type func() *zap.SugaredLogger has no field or method Named)
make: *** [build-go] Error 1
```
This was missed in https://github.com/edaniels/gostream/pull/11.