### PR TITLE
fix make test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cover:
 	go test -tags=no_skip -race -coverprofile=coverage.txt ./...
 
 test:
-	go test -tags=no_skip -race `go list -f '{{.Dir}}' ./... | grep -v mmal`
+	./test.sh
 
 stream-desktop: buf-go build-web
 	go run cmd/stream_video/main.go

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cover:
 	go test -tags=no_skip -race -coverprofile=coverage.txt ./...
 
 test:
-	go test -tags=no_skip -race ./...
+	go test -tags=no_skip -race `go list -f '{{.Dir}}' ./... | grep -v mmal`
 
 stream-desktop: buf-go build-web
 	go run cmd/stream_video/main.go

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+os="$(uname -s)"
+if [[ "$os" == "Darwin" ]]; then
+	args=$(go list -f '{{.Dir}}' ./... | grep -v mmal)
+else
+	args="./..."
+fi
+go test -tags=no_skip -race $args


### PR DESCRIPTION
This commit fixes the error
```
$ make test
...
# github.com/pion/mediadevices/pkg/codec/mmal
In file included from ../../go/pkg/mod/github.com/pion/mediadevices@v0.3.11/pkg/codec/mmal/mmal.go:8:
./bridge.h:1:10: fatal error: 'interface/mmal/mmal.h' file not found
#include <interface/mmal/mmal.h>
         ^~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
...
```

