### PR TITLE
unblock video path after webcam unplug

### DIFF
--- a/media.go
+++ b/media.go
@@ -123,7 +123,7 @@ func PropertiesFromMediaSource[T, U any](src MediaSource[T]) []prop.Media {
 			return asMedia.driver.Properties()
 		}
 	}
-	return make([]prop.Media, 0)
+	return nil
 }
 
 // newMediaSource instantiates a new media read closer and possibly references the given driver.

--- a/media.go
+++ b/media.go
@@ -3,6 +3,7 @@ package gostream
 import (
 	"context"
 	"errors"
+	"github.com/pion/mediadevices/pkg/prop"
 	"sync"
 	"sync/atomic"
 
@@ -115,6 +116,15 @@ type producerConsumer[T any, U any] struct {
 // regardless of whether or not the error is nil (This allows
 // for error handling logic based on consecutively retrieved errors).
 type ErrorHandler func(ctx context.Context, mediaErr error)
+
+func PropertiesFromMediaSource[T, U any](src MediaSource[T]) []prop.Media {
+	if asMedia, ok := src.(*mediaSource[T, U]); ok {
+		if asMedia.driver != nil {
+			return asMedia.driver.Properties()
+		}
+	}
+	return make([]prop.Media, 0)
+}
 
 // newMediaSource instantiates a new media read closer and possibly references the given driver.
 func newMediaSource[T, U any](d driver.Driver, r MediaReader[T], p U) MediaSource[T] {

--- a/query.go
+++ b/query.go
@@ -80,6 +80,18 @@ func GetNamedVideoSource(
 	return newVideoSourceFromDriver(d, selectedMedia, logger)
 }
 
+func GetStatusVideoSource(
+	name string,
+	constraints mediadevices.MediaStreamConstraints,
+	logger golog.Logger,
+) (driver.State, error) {
+	d, _, err := getUserVideoDriver(constraints, &name, logger)
+	if err != nil {
+		return driver.StateClosed, err
+	}
+	return d.Status(), nil
+}
+
 // GetPatternedVideoSource attempts to find a video device (not a screen) by the given label pattern.
 func GetPatternedVideoSource(
 	labelPattern *regexp.Regexp,

--- a/query.go
+++ b/query.go
@@ -80,15 +80,6 @@ func GetNamedVideoSource(
 	return newVideoSourceFromDriver(d, selectedMedia, logger)
 }
 
-func GetDriverVideoSource(
-	name string,
-	constraints mediadevices.MediaStreamConstraints,
-	logger golog.Logger,
-) (driver.Driver, error) {
-	d, _, err := getUserVideoDriver(constraints, &name, logger)
-	return d, err
-}
-
 // GetPatternedVideoSource attempts to find a video device (not a screen) by the given label pattern.
 func GetPatternedVideoSource(
 	labelPattern *regexp.Regexp,
@@ -482,24 +473,6 @@ func getAudioFilter(label *string) driver.FilterFn {
 		filter = driver.FilterAnd(filter, labelFilter(*label, true))
 	}
 	return filter
-}
-
-func SelectDriverByDeviceId(uuid string) driver.Driver {
-	filter := func(driver driver.Driver) bool {
-		for _, prop := range driver.Properties() {
-			if prop.DeviceID == uuid {
-				return true
-			}
-		}
-		return false
-	}
-
-	drivers := driver.GetManager().Query(filter)
-	if len(drivers) > 0 {
-		// because we're filtering on the UUID, there should only be one result
-		return drivers[0]
-	}
-	return nil
 }
 
 // select implements SelectSettings algorithm.


### PR DESCRIPTION
This commit is to help resolve [DATA-764](https://viam.atlassian.net/browse/DATA-764). The PR for that is https://github.com/viamrobotics/rdk/pull/1595. We need to monitor the status of the video driver to ensure we free resources after a webcam is unplugged. See the Jira ticket for more info and steps to reproduce.