### PR TITLE
expose driver from media source

### DIFF
--- a/media.go
+++ b/media.go
@@ -2,12 +2,11 @@ package gostream
 
 import (
 	"context"
-	"errors"
-	"github.com/pion/mediadevices/pkg/prop"
 	"sync"
 	"sync/atomic"
 
 	"github.com/pion/mediadevices/pkg/driver"
+	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.viam.com/utils"
 )
@@ -117,13 +116,13 @@ type producerConsumer[T any, U any] struct {
 // for error handling logic based on consecutively retrieved errors).
 type ErrorHandler func(ctx context.Context, mediaErr error)
 
-func PropertiesFromMediaSource[T, U any](src MediaSource[T]) []prop.Media {
+func DriverFromMediaSource[T, U any](src MediaSource[T]) (driver.Driver, error) {
 	if asMedia, ok := src.(*mediaSource[T, U]); ok {
 		if asMedia.driver != nil {
-			return asMedia.driver.Properties()
+			return asMedia.driver, nil
 		}
 	}
-	return nil
+	return nil, errors.Errorf("cannot convert media source (type %T) to type (%T)", src, (*mediaSource[T, U])(nil))
 }
 
 // newMediaSource instantiates a new media read closer and possibly references the given driver.


### PR DESCRIPTION
Instead of only exposing the properties from the driver I'm exposing the driver itself. To ensure we can reconnect to cameras I'll need the label from `driver.Info().Label`. This is needed for https://viam.atlassian.net/browse/DATA-597. Its PR is https://github.com/viamrobotics/rdk/pull/1644.