### PR TITLE
Add opusfile to Linux prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ macOS: `brew install x264`
 
 * opus
 
-Linux: `libopus-dev`
+Linux: `libopus-dev libopusfile-dev`
 
 macOS: `brew install opus`
 


### PR DESCRIPTION
Installing this solves this issue
```
pi@raspberrypi:/usr/local/libs/gostream $ make build-go
GOBIN=`pwd`/bin/gotools/Linux-aarch64  go install \
        `go list -f '{{ range $import := .Imports }} {{ $import }} {{ end }}' ./tools/tools.go`
PATH="`pwd`/bin/gotools/Linux-aarch64:`pwd`/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games" buf lint
PATH="`pwd`/bin/gotools/Linux-aarch64:`pwd`/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games" buf generate
go list -f '{{.Dir}}' ./... | grep -v mmal | xargs go build
# pkg-config --cflags  -- opus opus opus opus opusfile opusfile
Package opusfile was not found in the pkg-config search path.
Perhaps you should add the directory containing `opusfile.pc'
to the PKG_CONFIG_PATH environment variable
No package 'opusfile' found
Package opusfile was not found in the pkg-config search path.
Perhaps you should add the directory containing `opusfile.pc'
to the PKG_CONFIG_PATH environment variable
No package 'opusfile' found
pkg-config: exit status 1
```