### PR TITLE
do not close driver in use

### DIFF
--- a/query.go
+++ b/query.go
@@ -52,7 +52,7 @@ func GetNamedScreenSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetPatternedScreenSource attempts to find a screen device by the given label pattern.
@@ -65,7 +65,7 @@ func GetPatternedScreenSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetNamedVideoSource attempts to find a video device (not a screen) by the given name.
@@ -78,7 +78,7 @@ func GetNamedVideoSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetPatternedVideoSource attempts to find a video device (not a screen) by the given label pattern.
@@ -91,7 +91,7 @@ func GetPatternedVideoSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetAnyScreenSource attempts to find any suitable screen device.
@@ -103,7 +103,7 @@ func GetAnyScreenSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetAnyVideoSource attempts to find any suitable video device (not a screen).
@@ -115,7 +115,7 @@ func GetAnyVideoSource(
 	if err != nil {
 		return nil, err
 	}
-	return newVideoSourceFromDriver(d, selectedMedia, logger)
+	return newVideoSourceFromDriver(d, selectedMedia)
 }
 
 // GetAnyAudioSource attempts to find any suitable audio device.
@@ -281,7 +281,6 @@ func getUserVideoDriverPattern(
 func newVideoSourceFromDriver(
 	videoDriver driver.Driver,
 	mediaProp prop.Media,
-	logger golog.Logger,
 ) (MediaSource[image.Image], error) {
 	recorder, ok := videoDriver.(driver.VideoRecorder)
 	if !ok {
@@ -289,10 +288,7 @@ func newVideoSourceFromDriver(
 	}
 
 	if driverStatus := videoDriver.Status(); driverStatus != driver.StateClosed {
-		logger.Warnw("video driver is not closed, attempting to close and reopen", "status", driverStatus)
-		if err := videoDriver.Close(); err != nil {
-			logger.Errorw("error closing driver", "error", err)
-		}
+		return nil, errors.New("video driver in use")
 	}
 	if err := videoDriver.Open(); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a bug fix. To reproduce:
1. create a webcam (cam1) in app (no config info needed)
2. observe the cam1 is connected as expected.
3. create another webcam (cam2) in app that has the same config info as cam1.
4. observe cam2 closes cam1's driver and hijacks it for itself. Cam1 now gets EOF errors. 

The expected behavior is 
- cam1's driver remains untouched and still works as expected after another cam2 component is created.
- cam2 has no camera to connect to because the only available camera is in use.

This PR produces the expected behavior.

Side note, it'll be simpler to require user's to select a camera from our drop down menu. That will eliminate classes of issues like these where multiple camera components are fighting for the same driver. Any reason why we shouldn't do that?