### PR TITLE
RSDK-2654 allow camera discovery by pretty name

### DIFF
--- a/query.go
+++ b/query.go
@@ -369,7 +369,8 @@ func labelFilter(target string, useSep bool) driver.FilterFn {
 	})
 }
 
-func GetName(info driver.Info) (name string, id string) {
+// GetName returns the human-readable name and unique ID from a driver.Info.
+func GetName(info driver.Info) (name, id string) {
 	nameParts := strings.Split(info.Name, camera.LabelSeparator)
 	if len(nameParts) > 1 {
 		name, id = nameParts[0], nameParts[1]
@@ -382,7 +383,7 @@ func GetName(info driver.Info) (name string, id string) {
 	return
 }
 
-func parseNameAndId(toParse string) (name string, id string) {
+func parseNameAndID(toParse string) (name, id string) {
 	// expects '<camera_name> (<camera_id>)'
 	idIdx := strings.LastIndex(toParse, "(")
 	if idIdx == -1 {
@@ -409,13 +410,13 @@ func parseNameAndId(toParse string) (name string, id string) {
 
 func nameFilter(prettyName string) driver.FilterFn {
 	return func(d driver.Driver) bool {
-		expectedName, expectedId := parseNameAndId(prettyName)
-		if len(expectedName)+len(expectedId) == 0 {
+		expectedName, expectedID := parseNameAndID(prettyName)
+		if len(expectedName)+len(expectedID) == 0 {
 			return false
 		}
 
-		actualName, actualId := GetName(d.Info())
-		return actualName == expectedName && actualId == expectedId
+		actualName, actualID := GetName(d.Info())
+		return actualName == expectedName && actualID == expectedID
 	}
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -1,53 +1,54 @@
 package gostream
 
 import (
-	"go.viam.com/test"
 	"testing"
+
+	"go.viam.com/test"
 )
 
 func TestParseName(t *testing.T) {
 	prettyName := "Dummy video device (0x0000) (platform:v4l2loopback-000)"
-	name, id := parseNameAndId(prettyName)
+	name, id := parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldEqual, "Dummy video device (0x0000)")
 	test.That(t, id, test.ShouldEqual, "platform:v4l2loopback-000")
 
 	prettyName = "Mac OS X: FaceTime HD Camera (Built-in) (0x1420000005ac8600)"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldEqual, "Mac OS X: FaceTime HD Camera (Built-in)")
 	test.That(t, id, test.ShouldEqual, "0x1420000005ac8600")
 
 	prettyName = "Linux: Laptop Camera: Laptop Camera (usb-0000:00:14.0-7)"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldEqual, "Linux: Laptop Camera: Laptop Camera")
 	test.That(t, id, test.ShouldEqual, "usb-0000:00:14.0-7")
 
 	prettyName = "Linux: Laptop Camera: Laptop Camera (video0)"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldEqual, "Linux: Laptop Camera: Laptop Camera")
 	test.That(t, id, test.ShouldEqual, "video0")
 
 	prettyName = "ERROR: camera name ok but no parenthesis "
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldBeZeroValue)
 	test.That(t, id, test.ShouldBeZeroValue)
 
 	prettyName = "ERROR: camera name ok but no ID ()"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldBeZeroValue)
 	test.That(t, id, test.ShouldBeZeroValue)
 
 	prettyName = " (ERROR: ID ok but no name)"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldBeZeroValue)
 	test.That(t, id, test.ShouldBeZeroValue)
 
 	prettyName = "ERROR: camera name ok but (ID has no close parenthesis"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldBeZeroValue)
 	test.That(t, id, test.ShouldBeZeroValue)
 
 	prettyName = "ERROR: camera name ok but ID has no open parenthesis)"
-	name, id = parseNameAndId(prettyName)
+	name, id = parseNameAndID(prettyName)
 	test.That(t, name, test.ShouldBeZeroValue)
 	test.That(t, id, test.ShouldBeZeroValue)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,53 @@
+package gostream
+
+import (
+	"go.viam.com/test"
+	"testing"
+)
+
+func TestParseName(t *testing.T) {
+	prettyName := "Dummy video device (0x0000) (platform:v4l2loopback-000)"
+	name, id := parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldEqual, "Dummy video device (0x0000)")
+	test.That(t, id, test.ShouldEqual, "platform:v4l2loopback-000")
+
+	prettyName = "Mac OS X: FaceTime HD Camera (Built-in) (0x1420000005ac8600)"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldEqual, "Mac OS X: FaceTime HD Camera (Built-in)")
+	test.That(t, id, test.ShouldEqual, "0x1420000005ac8600")
+
+	prettyName = "Linux: Laptop Camera: Laptop Camera (usb-0000:00:14.0-7)"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldEqual, "Linux: Laptop Camera: Laptop Camera")
+	test.That(t, id, test.ShouldEqual, "usb-0000:00:14.0-7")
+
+	prettyName = "Linux: Laptop Camera: Laptop Camera (video0)"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldEqual, "Linux: Laptop Camera: Laptop Camera")
+	test.That(t, id, test.ShouldEqual, "video0")
+
+	prettyName = "ERROR: camera name ok but no parenthesis "
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldBeZeroValue)
+	test.That(t, id, test.ShouldBeZeroValue)
+
+	prettyName = "ERROR: camera name ok but no ID ()"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldBeZeroValue)
+	test.That(t, id, test.ShouldBeZeroValue)
+
+	prettyName = " (ERROR: ID ok but no name)"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldBeZeroValue)
+	test.That(t, id, test.ShouldBeZeroValue)
+
+	prettyName = "ERROR: camera name ok but (ID has no close parenthesis"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldBeZeroValue)
+	test.That(t, id, test.ShouldBeZeroValue)
+
+	prettyName = "ERROR: camera name ok but ID has no open parenthesis)"
+	name, id = parseNameAndId(prettyName)
+	test.That(t, name, test.ShouldBeZeroValue)
+	test.That(t, id, test.ShouldBeZeroValue)
+}


### PR DESCRIPTION
This is a bit hacky but works to find cameras by their pretty name that we'll expose to users.

#### Testing
I manually tested this by ensuring we could
- Connect to cameras by select their pretty name in the drop-down
- Connect to the same camera after it has been moved to another USB port
- Connect to the same camera after its `/dev/videoN` path has changed.